### PR TITLE
Also reset Y on iterating Z

### DIFF
--- a/sakura-server/src/main/java/me/samsuik/sakura/utils/BlockPosIterator.java
+++ b/sakura-server/src/main/java/me/samsuik/sakura/utils/BlockPosIterator.java
@@ -58,6 +58,7 @@ public final class BlockPosIterator extends AbstractIterator<BlockPos> {
             } else if (z < this.endZ) {
                 z += 1;
                 x = this.startX;
+                y = this.startY;
             } else {
                 return this.endOfData();
             }


### PR DESCRIPTION
Reset Y on iterating Z to prevent skip the entire Y during Z iteration, to follow the original behavior.

To replicate:
<img width="869" height="780" alt="image" src="https://github.com/user-attachments/assets/ae84c9ef-7628-4f00-998e-52586a457db9" />
Place rails over the cauldron filled with lava, place the minecart on the sloped rails, and try pushing the minecart towards the cauldron. The expected result is the minecart get killed when it gets pushed close enough to the cauldron.